### PR TITLE
Use is_cli instead

### DIFF
--- a/application/controllers/cli/Create.php
+++ b/application/controllers/cli/Create.php
@@ -6,7 +6,7 @@ class Create extends CI_Controller {
     {
         parent::__construct();
 
-        if( ! $this->input->is_cli_request())
+        if( ! is_cli())
         {
             show_404();
         }


### PR DESCRIPTION
https://github.com/bcit-ci/CodeIgniter/blob/develop/system%2Fcore%2FCommon.php#L373

Langsung pake is_cli coz is_cli_request udah deprecated :-)

Dan tolong buat PR ke main repo CI tuk tambah pengecekan biar user tak perlu ngecek lagi... Harusnya CLI cuma bisa diexecute dari local ga bisa remote
